### PR TITLE
Fix Hidden Dimension Mismatch in train_simple_gnn_model

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,7 +48,7 @@ def main():
     # Perform the specified action
     if args.action == "train":
         if args.model_type == "simple":
-            train_simple_gnn_model()
+            train_simple_gnn_model(hidden_dim=args.hidden_dim)
         elif args.model_type == "generalized":
             train_generalized_gnn_model(
                 variant=args.variant,

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -7,13 +7,13 @@ from models.gnn_model import GNNModel
 from utils.config import Config
 
 
-def train_simple_gnn_model():
+def train_simple_gnn_model(hidden_dim):
     # Load the dataset
     dataset = DatasetLoader("Cora").load()
     data = dataset[0]
 
     # Initialize the simple GNN model
-    model = GNNModel(input_dim=dataset.num_features, hidden_dim=16, output_dim=dataset.num_classes)
+    model = GNNModel(input_dim=dataset.num_features, hidden_dim=hidden_dim, output_dim=dataset.num_classes)
 
     optimizer = optim.Adam(model.parameters(), lr=Config.LEARNING_RATE, weight_decay=Config.WEIGHT_DECAY)
 


### PR DESCRIPTION
This PR resolves the issue of state dict size mismatch during evaluation and cross-dataset testing for the Simple GNN model. The mismatch was caused by inconsistent hidden dimension sizes between training and evaluation.

closes #12 